### PR TITLE
Revert pull request #502: "Add option to clone specific ref of repo"

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -16,11 +16,6 @@ on:
         default: "3.0.3"
         required: true
         type: string
-      uyouenhanced_version:
-        description: "The version of uYouEnhanced (Commit ID)"
-        default: "main"
-        required: true
-        type: string
       decrypted_youtube_url:
         description: "The direct URL to the decrypted YouTube ipa"
         default: ""
@@ -63,7 +58,6 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           path: main
-          ref: ${{ inputs.uyouenhanced_version }}
           submodules: recursive
 
       - name: Install Dependencies


### PR DESCRIPTION
As mentioned in the comments on #502 this doesn't do much on forks as the SHAs are all different and tags don't copy over, this really is more useful in a action that clones the main repo

PS, sorry for the trouble