### PR TITLE
Fix/fake premium toggle

### DIFF
--- a/Sources/uYouPlus.xm
+++ b/Sources/uYouPlus.xm
@@ -316,22 +316,21 @@ BOOL isAd(YTIElementRenderer *self) {
 %group gFakePremium
 // YouTube Premium Logo - @arichornlover & bhackel
 %hook YTHeaderLogoController
-    - (void)setTopbarLogoRenderer:(id)renderer {
-        // Modify the type of the icon before setting the renderer
-        YTITopbarLogoRenderer *logoRenderer = (YTITopbarLogoRenderer *)renderer;
-        YTIIcon *iconImage = logoRenderer.iconImage;
-        iconImage.iconType = 537; // magic number for Premium icon, hopefully it doesnt change. 158 is default logo.
-        // Use this modified renderer
-        %orig(logoRenderer);
-    }
-    // For when spoofing before 18.34.5
-    - (void)setPremiumLogo:(BOOL)isPremiumLogo {
-        isPremiumLogo = YES;
-        %orig;
-    }
-    - (BOOL)isPremiumLogo {
-        return YES;
-    }
+- (void)setTopbarLogoRenderer:(YTITopbarLogoRenderer)renderer {
+    // Modify the type of the icon before setting the renderer
+    YTIIcon *iconImage = renderer.iconImage;
+    iconImage.iconType = 537; // magic number for Premium icon, hopefully it doesnt change. 158 is default logo.
+    // Use this modified renderer
+    %orig;
+}
+// For when spoofing before 18.34.5
+- (void)setPremiumLogo:(BOOL)isPremiumLogo {
+    isPremiumLogo = YES;
+    %orig;
+}
+- (BOOL)isPremiumLogo {
+    return YES;
+}
 %end
 %hook YTAppCollectionViewController
 /**

--- a/Sources/uYouPlus.xm
+++ b/Sources/uYouPlus.xm
@@ -1587,13 +1587,13 @@ static BOOL findCell(ASNodeController *nodeController, NSArray <NSString *> *ide
     // YTNoModernUI - @arichorn
     BOOL ytNoModernUIEnabled = IS_ENABLED(@"ytNoModernUI_enabled");
     if (ytNoModernUIEnabled) {
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    [userDefaults setBool:NO forKey:@"enableVersionSpoofer_enabled"];
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults setBool:NO forKey:@"enableVersionSpoofer_enabled"];
     } else {
-    BOOL enableVersionSpooferEnabled = IS_ENABLED(@"enableVersionSpoofer_enabled");
+        BOOL enableVersionSpooferEnabled = IS_ENABLED(@"enableVersionSpoofer_enabled");
 
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    [userDefaults setBool:enableVersionSpooferEnabled forKey:@"enableVersionSpoofer_enabled"];
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults setBool:enableVersionSpooferEnabled forKey:@"enableVersionSpoofer_enabled"];
     }
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setBool:ytNoModernUIEnabled ? ytNoModernUIEnabled : [userDefaults boolForKey:@"fixLowContrastMode_enabled"] forKey:@"fixLowContrastMode_enabled"];

--- a/Sources/uYouPlus.xm
+++ b/Sources/uYouPlus.xm
@@ -316,7 +316,7 @@ BOOL isAd(YTIElementRenderer *self) {
 %group gFakePremium
 // YouTube Premium Logo - @arichornlover & bhackel
 %hook YTHeaderLogoController
-- (void)setTopbarLogoRenderer:(YTITopbarLogoRenderer)renderer {
+- (void)setTopbarLogoRenderer:(YTITopbarLogoRenderer *)renderer {
     // Modify the type of the icon before setting the renderer
     YTIIcon *iconImage = renderer.iconImage;
     iconImage.iconType = 537; // magic number for Premium icon, hopefully it doesnt change. 158 is default logo.

--- a/Sources/uYouPlus.xm
+++ b/Sources/uYouPlus.xm
@@ -341,6 +341,13 @@ BOOL isAd(YTIElementRenderer *self) {
   */
 %new
 - (void)uYouEnhancedFakePremiumModel:(YTISectionListRenderer *)model {
+    // Don't do anything if the version is too low
+    Class YTVersionUtilsClass = %c(YTVersionUtils);
+    NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+    NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch];
+    if (result == NSOrderedAscending) {
+        return;
+    }
     NSUInteger yourVideosCellIndex = -1;
     NSMutableArray <YTISectionListSupportedRenderers *> *overallContentsArray = model.contentsArray;
     // Check each item in the overall array - this represents the whole You page

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -1020,8 +1020,20 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     accessibilityIdentifier:nil
     switchOn:IS_ENABLED(@"youTabFakePremium_enabled")
     switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
+        // Store the received value
+        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"youTabFakePremium_enabled"];
         NSLog(@"backel: Switch toggled: %@", enabled ? @"ON" : @"OFF");
-        NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+        // Get the current version (including spoofed versions)
+        NSString *appVersion;
+        Class YTVersionUtilsClass = %c(YTVersionUtils);
+        if ([YTVersionUtilsClass respondsToSelector:@selector(appVersion)]) {
+            appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+            NSLog(@"backel: App Version: %@", appVersion);
+        } else {
+            NSLog(@"backel: The YTVersionUtils class does not respond to -appVersion");
+        }
+        // appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+        // Check if current version is less than the required version
         NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch];
         NSLog(@"backel: App Version: %@, Required: 18.35.4, Result: %ld", appVersion, (long)result);
         if (result == NSOrderedAscending) {

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -1022,39 +1022,25 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
         // Store the received value
         [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"youTabFakePremium_enabled"];
-        NSLog(@"backel: Switch toggled: %@", enabled ? @"ON" : @"OFF");
         // Get the current version (including spoofed versions)
-        NSString *appVersion;
         Class YTVersionUtilsClass = %c(YTVersionUtils);
-        if ([YTVersionUtilsClass respondsToSelector:@selector(appVersion)]) {
-            appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
-            NSLog(@"backel: App Version: %@", appVersion);
-        } else {
-            NSLog(@"backel: The YTVersionUtils class does not respond to -appVersion");
-        }
-        // appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-        // Check if current version is less than the required version
+        NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+        // Alert if the version is partially incompatible and the toggle is being turned on
         NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch];
-        NSLog(@"backel: App Version: %@, Required: 18.35.4, Result: %ld", appVersion, (long)result);
-        if (result == NSOrderedAscending) {
-            NSLog(@"backel: Incompatible version detected: %@", appVersion);
-            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"Error: The \"You\" Tab doesn't exist in v%@. \nFake Premium is only available for app versions v18.35.4 and higher.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
+        if (enabled && result == NSOrderedAscending) {
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"Warning: The \"You\" Tab doesn't exist in v%@.\nFake Logo will still work.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
             UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
             [alert addAction:okAction];
             [settingsViewController presentViewController:alert animated:YES completion:nil];
-            [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"youTabFakePremium_enabled"];
-            return NO;
         }
+        // Refresh data and show the relaunch popup
         [settingsViewController reloadData];
         SHOW_RELAUNCH_YT_SNACKBAR;
         return YES;
     }
     settingItemId:0
-];
-[sectionItems addObject:fakePremium];
-
-// Additional logging for initial load
-NSLog(@"backel: youTabFakePremium_enabled is currently set to: %@", IS_ENABLED(@"youTabFakePremium_enabled") ? @"YES" : @"NO");
+    ];
+    [sectionItems addObject:fakePremium];
 
 
 //  SWITCH_ITEM(LOC(@"Center YouTube Logo"), LOC(@"Toggle this to move the official YouTube Logo to the Center. App restart is required."), @"centerYouTubeLogo_enabled");

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -9,9 +9,45 @@
 
 #define SECTION_HEADER(s) [sectionItems addObject:[%c(YTSettingsSectionItem) itemWithTitle:@"\t" titleDescription:[s uppercaseString] accessibilityIdentifier:nil detailTextBlock:nil selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger sectionItemIndex) { return NO; }]]
 
-#define SWITCH_ITEM(t, d, k) [sectionItems addObject:[YTSettingsSectionItemClass switchItemWithTitle:t titleDescription:d accessibilityIdentifier:nil switchOn:IS_ENABLED(k) switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:k];return YES;} settingItemId:0]]
+// Basic Switch Item
+#define SWITCH_ITEM(t, d, k) \
+    [sectionItems addObject:[YTSettingsSectionItemClass \
+        switchItemWithTitle:t \
+        titleDescription:d \
+        accessibilityIdentifier:nil \
+        switchOn:IS_ENABLED(k) \
+        switchBlock:^BOOL (YTSettingsCell *cell, BOOL enable) { \
+            [[NSUserDefaults standardUserDefaults] setBool:enable forKey:k]; \
+            return YES; \
+        } \
+        settingItemId:0]]
 
-#define SWITCH_ITEM2(t, d, k) [sectionItems addObject:[YTSettingsSectionItemClass switchItemWithTitle:t titleDescription:d accessibilityIdentifier:nil switchOn:IS_ENABLED(k) switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:k];SHOW_RELAUNCH_YT_SNACKBAR;return YES;} settingItemId:0]]
+// Switch Item with Restart popup
+#define SWITCH_ITEM2(t, d, k) \
+    [sectionItems addObject:[YTSettingsSectionItemClass \
+        switchItemWithTitle:t \
+        titleDescription:d \
+        accessibilityIdentifier:nil \
+        switchOn:IS_ENABLED(k) \
+        switchBlock:^BOOL (YTSettingsCell *cell, BOOL enable) { \
+            [[NSUserDefaults standardUserDefaults] setBool:enable forKey:k]; \
+            SHOW_RELAUNCH_YT_SNACKBAR; \
+            return YES; \
+        } \
+        settingItemId:0]]
+
+// Switch Item with customizable code
+#define SWITCH_ITEM3(title, description, key, code) \
+    [sectionItems addObject:[YTSettingsSectionItemClass \
+        switchItemWithTitle:title \
+        titleDescription:description \
+        accessibilityIdentifier:nil \
+        switchOn:IS_ENABLED(key) \
+        switchBlock:^BOOL (YTSettingsCell *cell, BOOL enable) { \
+            code \
+        } \
+        settingItemId:0]]
+
 
 static int contrastMode() {
     NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
@@ -334,95 +370,87 @@ extern NSBundle *uYouPlusBundle();
     SECTION_HEADER(LOC(@"UI Interface Options"));
 
     SWITCH_ITEM2(LOC(@"Hide Home Tab"), LOC(@""), @"hideHomeTab_enabled");
-
-YTSettingsSectionItem *lowContrastMode = [YTSettingsSectionItemClass
-    switchItemWithTitle:LOC(@"Low Contrast Mode")
-    titleDescription:LOC(@"This will lower the contrast of texts and buttons, similar to the old YouTube Interface. App restart is required.")
-    accessibilityIdentifier:nil
-    switchOn:IS_ENABLED(@"lowContrastMode_enabled")
-    switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
-        if (enabled) {
-            // Get the current version (including spoofed versions)
-            Class YTVersionUtilsClass = %c(YTVersionUtils);
-            NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
-            // Compare the current version to the supported version range
-            NSComparisonResult result1 = [appVersion compare:@"17.33.2" options:NSNumericSearch];
-            NSComparisonResult result2 = [appVersion compare:@"17.38.10" options:NSNumericSearch];
-            if (result1 == NSOrderedAscending) {
-                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Discontinued" message:[NSString stringWithFormat:@"You are using v%@ which is a discontinued version of YouTube that no longer works. Please use v17.33.2-17.38.10 in order to use LowContrastMode.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
-                UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
-                [alert addAction:okAction];
-                [settingsViewController presentViewController:alert animated:YES completion:nil];
-                return NO;
+    SWITCH_ITEM3(
+        LOC(@"Low Contrast Mode"),
+        LOC(@"This will lower the contrast of texts and buttons, similar to the old YouTube Interface."),
+        @"lowContrastMode_enabled",
+        ({
+            if (enable) {
+                Class YTVersionUtilsClass = %c(YTVersionUtils);
+                NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+                NSComparisonResult result1 = [appVersion compare:@"17.33.2" options:NSNumericSearch];
+                NSComparisonResult result2 = [appVersion compare:@"17.38.10" options:NSNumericSearch];
+                if (result1 == NSOrderedAscending) {
+                    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Discontinued" message:[NSString stringWithFormat:@"You are using v%@ which is a discontinued version of YouTube that no longer works. Please use v17.33.2-17.38.10 in order to use LowContrastMode.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
+                    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+                    [alert addAction:okAction];
+                    [settingsViewController presentViewController:alert animated:YES completion:nil];
+                    return NO;
+                } else if (result2 == NSOrderedDescending) {
+                    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"LowContrastMode is only available for app versions v17.33.2-v17.38.10. \nYou are currently using v%@. \nWorkaround: if you want to use this then I recommend enabling \"Fix LowContrastMode\" Option.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
+                    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+                    [alert addAction:okAction];
+                    [settingsViewController presentViewController:alert animated:YES completion:nil];
+                    return NO;
+                }
             }
-            else if (result2 == NSOrderedDescending) {
-                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"LowContrastMode is only available for app versions v17.33.2-v17.38.10. \nYou are currently using v%@. \nWorkaround: if you want to use this then I recommend enabling \"Fix LowContrastMode\" Option.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
-                UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
-                [alert addAction:okAction];
-                [settingsViewController presentViewController:alert animated:YES completion:nil];
-                return NO;
-            }
-        }
-        // Refresh the stored value
-        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"lowContrastMode_enabled"];
-        [settingsViewController reloadData];
-        SHOW_RELAUNCH_YT_SNACKBAR;
-        return YES;
-    }
-    settingItemId:0
-];
-[sectionItems addObject:lowContrastMode];
-
-YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
-    itemWithTitle:@"Low Contrast Mode Selector"
-    accessibilityIdentifier:nil
-    detailTextBlock:^NSString *() {
-        switch (contrastMode()) {
-            case 1:
-                return LOC(@"Custom Color");
-            case 0:
-            default:
-                return LOC(@"Default");
-        }
-    }
-    selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
-        if (contrastMode() == 0) {
-            // Get the current version (including spoofed versions)
-            Class YTVersionUtilsClass = %c(YTVersionUtils);
-            NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
-            // Alert the user that they need to enable the fix
-            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatibile" message:[NSString stringWithFormat:@"LowContrastMode is only available for app versions v17.33.2-v17.38.10. \nYou are currently using v%@. \n\nWorkaround: if you want to use this then I recommend enabling \"Fix LowContrastMode\" Option.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
-            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
-            [alert addAction:okAction];
-            [settingsViewController presentViewController:alert animated:YES completion:nil];
-            return NO;
-        } else {
-            NSArray <YTSettingsSectionItem *> *rows = @[
-                [YTSettingsSectionItemClass checkmarkItemWithTitle:LOC(@"Default") titleDescription:nil selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
-                    [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:@"lcm"];
-                    [settingsViewController reloadData];
-                    return YES;
-                }],
-                [YTSettingsSectionItemClass checkmarkItemWithTitle:LOC(@"Custom Color") titleDescription:nil selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
-                    [[NSUserDefaults standardUserDefaults] setInteger:1 forKey:@"lcm"];
-                    [settingsViewController reloadData];
-                    return YES;
-                }]
-
-            ];
-            YTSettingsPickerViewController *picker = [[%c(YTSettingsPickerViewController) alloc] initWithNavTitle:LOC(@"Low Contrast Mode Selector") pickerSectionTitle:nil rows:rows selectedItemIndex:contrastMode() parentResponder:[self parentResponder]];
-            [settingsViewController pushViewController:picker];
+            [[NSUserDefaults standardUserDefaults] setBool:enable forKey:@"lowContrastMode_enabled"];
+            [settingsViewController reloadData];
+            SHOW_RELAUNCH_YT_SNACKBAR;
             return YES;
+        })
+    );
+    YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
+        itemWithTitle:@"Low Contrast Mode Selector"
+        accessibilityIdentifier:nil
+        detailTextBlock:^NSString *() {
+            switch (contrastMode()) {
+                case 1:
+                    return LOC(@"Custom Color");
+                case 0:
+                default:
+                    return LOC(@"Default");
+            }
         }
-    }
-];
-[sectionItems addObject:lowContrastModeButton];
+        selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
+            if (contrastMode() == 0) {
+                // Get the current version (including spoofed versions)
+                Class YTVersionUtilsClass = %c(YTVersionUtils);
+                NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+                // Alert the user that they need to enable the fix
+                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatibile" message:[NSString stringWithFormat:@"LowContrastMode is only available for app versions v17.33.2-v17.38.10. \nYou are currently using v%@. \n\nWorkaround: if you want to use this then I recommend enabling \"Fix LowContrastMode\" Option.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
+                UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+                [alert addAction:okAction];
+                [settingsViewController presentViewController:alert animated:YES completion:nil];
+                return NO;
+            } else {
+                NSArray <YTSettingsSectionItem *> *rows = @[
+                    [YTSettingsSectionItemClass checkmarkItemWithTitle:LOC(@"Default") titleDescription:nil selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
+                        [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:@"lcm"];
+                        [settingsViewController reloadData];
+                        return YES;
+                    }],
+                    [YTSettingsSectionItemClass checkmarkItemWithTitle:LOC(@"Custom Color") titleDescription:nil selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
+                        [[NSUserDefaults standardUserDefaults] setInteger:1 forKey:@"lcm"];
+                        [settingsViewController reloadData];
+                        return YES;
+                    }]
+
+                ];
+                YTSettingsPickerViewController *picker = [[%c(YTSettingsPickerViewController) alloc] initWithNavTitle:LOC(@"Low Contrast Mode Selector") pickerSectionTitle:nil rows:rows selectedItemIndex:contrastMode() parentResponder:[self parentResponder]];
+                [settingsViewController pushViewController:picker];
+                return YES;
+            }
+        }
+    ];
+    [sectionItems addObject:lowContrastModeButton];
     SWITCH_ITEM2(LOC(@"Fix LowContrastMode"), LOC(@"This will fix the LowContrastMode functionality by Spoofing to YouTube v17.38.10. App restart is required."), @"fixLowContrastMode_enabled");
     SWITCH_ITEM2(LOC(@"Disable Modern Buttons"), LOC(@"This will remove the new Modern / Chip Buttons in the YouTube App. but not all of them. App restart is required."), @"disableModernButtons_enabled");
     SWITCH_ITEM2(LOC(@"Disable Rounded Corners on Hints"), LOC(@"This will make the Hints in the App to not have Rounded Corners. App restart is required."), @"disableRoundedHints_enabled");
     SWITCH_ITEM2(LOC(@"Disable Modern A/B Flags"), LOC(@"This will turn off any Modern Flag that was enabled by default. App restart is required."), @"disableModernFlags_enabled");
     SWITCH_ITEM2(LOC(@"Enable Specific UI Related Options (YTNoModernUI)"), LOC(@"This will force-enable other options to give it a less-modern feeling. App restart is required."), @"ytNoModernUI_enabled");
     SWITCH_ITEM2(LOC(@"Enable App Version Spoofer"), LOC(@"Enable this to use the Version Spoofer and select your perferred version below. App restart is required."), @"enableVersionSpoofer_enabled");
+    
     YTSettingsSectionItem *versionSpoofer = [%c(YTSettingsSectionItem)
         itemWithTitle:@"Version spoofer picker"
         accessibilityIdentifier:nil
@@ -1019,35 +1047,29 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     SECTION_HEADER(LOC(@"MISCELLANEOUS"));
 
     SWITCH_ITEM2(LOC(@"Adblock Workaround"), LOC(@"Uses stronger adblocking code"), @"uYouAdBlockingWorkaround_enabled");
-
-    YTSettingsSectionItem *fakePremium = [YTSettingsSectionItemClass
-    switchItemWithTitle:LOC(@"Fake Premium")
-    titleDescription:LOC(@"Uses Premium logo and creates fake buttons in the You tab")
-    accessibilityIdentifier:nil
-    switchOn:IS_ENABLED(@"youTabFakePremium_enabled")
-    switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
-        // Get the current version (including spoofed versions)
-        Class YTVersionUtilsClass = %c(YTVersionUtils);
-        NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
-        // Alert if the version is partially incompatible and the toggle is being turned on
-        NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch];
-        if (enabled && result == NSOrderedAscending) {
-            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"Warning: The \"You\" Tab doesn't exist in v%@.\nFake Logo will still work.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
-            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
-            [alert addAction:okAction];
-            [settingsViewController presentViewController:alert animated:YES completion:nil];
-        }
-        // Refresh data and show the relaunch popup
-        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"youTabFakePremium_enabled"];
-        [settingsViewController reloadData];
-        SHOW_RELAUNCH_YT_SNACKBAR;
-        return YES;
-    }
-    settingItemId:0
-    ];
-    [sectionItems addObject:fakePremium];
-
-
+    SWITCH_ITEM3(
+        LOC(@"Fake Premium"),
+        LOC(@"Uses Premium logo and creates fake buttons in the You tab"),
+        @"youTabFakePremium_enabled",
+        ({
+            // Get the current version (including spoofed versions)
+            Class YTVersionUtilsClass = %c(YTVersionUtils);
+            NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+            // Alert if the version is partially incompatible and the toggle is being turned on
+            NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch];
+            if (enabled && result == NSOrderedAscending) {
+                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"Warning: The \"You\" Tab doesn't exist in v%@.\nFake Logo will still work.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
+                UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+                [alert addAction:okAction];
+                [settingsViewController presentViewController:alert animated:YES completion:nil];
+            }
+            // Refresh data and show the relaunch popup
+            [[NSUserDefaults standardUserDefaults] setBool:enable forKey:@"youTabFakePremium_enabled"];
+            [settingsViewController reloadData];
+            SHOW_RELAUNCH_YT_SNACKBAR;
+            return YES;
+        })
+    );
 //  SWITCH_ITEM(LOC(@"Center YouTube Logo"), LOC(@"Toggle this to move the official YouTube Logo to the Center. App restart is required."), @"centerYouTubeLogo_enabled");
     SWITCH_ITEM(LOC(@"Hide YouTube Logo"), LOC(@"Toggle this to hide the YouTube Logo in the YouTube App."), @"hideYouTubeLogo_enabled");
     SWITCH_ITEM2(LOC(@"ENABLE_YT_STARTUP_ANIMATION"), LOC(@"ENABLE_YT_STARTUP_ANIMATION_DESC"), @"ytStartupAnimation_enabled");

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -398,7 +398,7 @@ extern NSBundle *uYouPlusBundle();
             [settingsViewController reloadData];
             SHOW_RELAUNCH_YT_SNACKBAR;
             return YES;
-        })
+        });
     );
     YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
         itemWithTitle:@"Low Contrast Mode Selector"
@@ -1057,7 +1057,7 @@ extern NSBundle *uYouPlusBundle();
             NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
             // Alert if the version is partially incompatible and the toggle is being turned on
             NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch];
-            if (enabled && result == NSOrderedAscending) {
+            if (enable && result == NSOrderedAscending) {
                 UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"Warning: The \"You\" Tab doesn't exist in v%@.\nFake Logo will still work.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
                 UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
                 [alert addAction:okAction];
@@ -1068,7 +1068,7 @@ extern NSBundle *uYouPlusBundle();
             [settingsViewController reloadData];
             SHOW_RELAUNCH_YT_SNACKBAR;
             return YES;
-        })
+        });
     );
 //  SWITCH_ITEM(LOC(@"Center YouTube Logo"), LOC(@"Toggle this to move the official YouTube Logo to the Center. App restart is required."), @"centerYouTubeLogo_enabled");
     SWITCH_ITEM(LOC(@"Hide YouTube Logo"), LOC(@"Toggle this to hide the YouTube Logo in the YouTube App."), @"hideYouTubeLogo_enabled");

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -1012,7 +1012,7 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     # pragma mark - Miscellaneous
     SECTION_HEADER(LOC(@"MISCELLANEOUS"));
 
-    SWITCH_ITEM2(LOC(@"Adblock Workaround"), LOC(@"Uses stronger adblocking code. Can cause blank spots on homepage"), @"uYouAdBlockingWorkaround_enabled");
+    SWITCH_ITEM2(LOC(@"Adblock Workaround"), LOC(@"Uses stronger adblocking code"), @"uYouAdBlockingWorkaround_enabled");
 
     YTSettingsSectionItem *fakePremium = [YTSettingsSectionItemClass
     switchItemWithTitle:LOC(@"Fake Premium")
@@ -1020,9 +1020,12 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     accessibilityIdentifier:nil
     switchOn:IS_ENABLED(@"youTabFakePremium_enabled")
     switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
+        NSLog(@"backel: Switch toggled: %@", enabled ? @"ON" : @"OFF");
         NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-        NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch]; 
+        NSComparisonResult result = [appVersion compare:@"18.35.4" options:NSNumericSearch];
+        NSLog(@"backel: App Version: %@, Required: 18.35.4, Result: %ld", appVersion, (long)result);
         if (result == NSOrderedAscending) {
+            NSLog(@"backel: Incompatible version detected: %@", appVersion);
             UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatible" message:[NSString stringWithFormat:@"Error: The \"You\" Tab doesn't exist in v%@. \nFake Premium is only available for app versions v18.35.4 and higher.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
             UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
             [alert addAction:okAction];
@@ -1037,6 +1040,10 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     settingItemId:0
 ];
 [sectionItems addObject:fakePremium];
+
+// Additional logging for initial load
+NSLog(@"backel: youTabFakePremium_enabled is currently set to: %@", IS_ENABLED(@"youTabFakePremium_enabled") ? @"YES" : @"NO");
+
 
 //  SWITCH_ITEM(LOC(@"Center YouTube Logo"), LOC(@"Toggle this to move the official YouTube Logo to the Center. App restart is required."), @"centerYouTubeLogo_enabled");
     SWITCH_ITEM(LOC(@"Hide YouTube Logo"), LOC(@"Toggle this to hide the YouTube Logo in the YouTube App."), @"hideYouTubeLogo_enabled");

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -48,6 +48,29 @@
         } \
         settingItemId:0]]
 
+/** Example SWITCH_ITEM3 Usage
+SWITCH_ITEM3(
+    LOC(@"Your title here"), 
+    LOC(@"Your description here"), 
+    @"yourKey_enabled",
+    // Custom code goes in this block, wrapped in ({...}); Make sure to return YES at the end
+    ({
+        // Show an alert if this setting is being enabled
+        if (enable) {
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Warning" message:@"Some alert message here" preferredStyle:UIAlertControllerStyleAlert];
+            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+            [alert addAction:okAction];
+            [settingsViewController presentViewController:alert animated:YES completion:nil];
+        }
+        // Update the setting in the storage and reload
+        [[NSUserDefaults standardUserDefaults] setBool:enable forKey:@"yourKey_enabled"];
+        [settingsViewController reloadData];
+        SHOW_RELAUNCH_YT_SNACKBAR;
+        return YES;
+    });
+);
+*/
+
 
 static int contrastMode() {
     NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
@@ -451,7 +474,7 @@ extern NSBundle *uYouPlusBundle();
     SWITCH_ITEM3(
         LOC(@"Enable Specific UI Related Options (YTNoModernUI)"), 
         LOC(@"This will enable other options to give it a less-modern feeling. App restart is required."), 
-        @"ytNoModernUI_enabled"
+        @"ytNoModernUI_enabled",
         ({
             if (enable) {
                 UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Warning" message:@"This will force-enable other settings on restart. To disable them, you must turn this setting off." preferredStyle:UIAlertControllerStyleAlert];

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -448,7 +448,23 @@ extern NSBundle *uYouPlusBundle();
     SWITCH_ITEM2(LOC(@"Disable Modern Buttons"), LOC(@"This will remove the new Modern / Chip Buttons in the YouTube App. but not all of them. App restart is required."), @"disableModernButtons_enabled");
     SWITCH_ITEM2(LOC(@"Disable Rounded Corners on Hints"), LOC(@"This will make the Hints in the App to not have Rounded Corners. App restart is required."), @"disableRoundedHints_enabled");
     SWITCH_ITEM2(LOC(@"Disable Modern A/B Flags"), LOC(@"This will turn off any Modern Flag that was enabled by default. App restart is required."), @"disableModernFlags_enabled");
-    SWITCH_ITEM2(LOC(@"Enable Specific UI Related Options (YTNoModernUI)"), LOC(@"This will force-enable other options to give it a less-modern feeling. App restart is required."), @"ytNoModernUI_enabled");
+    SWITCH_ITEM3(
+        LOC(@"Enable Specific UI Related Options (YTNoModernUI)"), 
+        LOC(@"This will enable other options to give it a less-modern feeling. App restart is required."), 
+        @"ytNoModernUI_enabled"
+        ({
+            if (enable) {
+                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Warning" message:@"This will force-enable other settings on restart. To disable them, you must turn this setting off." preferredStyle:UIAlertControllerStyleAlert];
+                UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+                [alert addAction:okAction];
+                [settingsViewController presentViewController:alert animated:YES completion:nil];
+            }
+            [[NSUserDefaults standardUserDefaults] setBool:enable forKey:@"ytNoModernUI_enabled"];
+            [settingsViewController reloadData];
+            SHOW_RELAUNCH_YT_SNACKBAR;
+            return YES;
+        });
+    );
     SWITCH_ITEM2(LOC(@"Enable App Version Spoofer"), LOC(@"Enable this to use the Version Spoofer and select your perferred version below. App restart is required."), @"enableVersionSpoofer_enabled");
     
     YTSettingsSectionItem *versionSpoofer = [%c(YTSettingsSectionItem)

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -342,7 +342,10 @@ YTSettingsSectionItem *lowContrastMode = [YTSettingsSectionItemClass
     switchOn:IS_ENABLED(@"lowContrastMode_enabled")
     switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
         if (enabled) {
-            NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+            // Get the current version (including spoofed versions)
+            Class YTVersionUtilsClass = %c(YTVersionUtils);
+            NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+            // Compare the current version to the supported version range
             NSComparisonResult result1 = [appVersion compare:@"17.33.2" options:NSNumericSearch];
             NSComparisonResult result2 = [appVersion compare:@"17.38.10" options:NSNumericSearch];
             if (result1 == NSOrderedAscending) {
@@ -360,9 +363,8 @@ YTSettingsSectionItem *lowContrastMode = [YTSettingsSectionItemClass
                 return NO;
             }
         }
-        if (IS_ENABLED(@"fixLowContrastMode_enabled")) {
-            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"lowContrastMode_enabled"];
-        }
+        // Refresh the stored value
+        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"lowContrastMode_enabled"];
         [settingsViewController reloadData];
         SHOW_RELAUNCH_YT_SNACKBAR;
         return YES;
@@ -370,6 +372,7 @@ YTSettingsSectionItem *lowContrastMode = [YTSettingsSectionItemClass
     settingItemId:0
 ];
 [sectionItems addObject:lowContrastMode];
+
 YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     itemWithTitle:@"Low Contrast Mode Selector"
     accessibilityIdentifier:nil
@@ -384,7 +387,10 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     }
     selectBlock:^BOOL (YTSettingsCell *cell, NSUInteger arg1) {
         if (contrastMode() == 0) {
-            NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+            // Get the current version (including spoofed versions)
+            Class YTVersionUtilsClass = %c(YTVersionUtils);
+            NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
+            // Alert the user that they need to enable the fix
             UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incompatibile" message:[NSString stringWithFormat:@"LowContrastMode is only available for app versions v17.33.2-v17.38.10. \nYou are currently using v%@. \n\nWorkaround: if you want to use this then I recommend enabling \"Fix LowContrastMode\" Option.", appVersion] preferredStyle:UIAlertControllerStyleAlert];
             UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
             [alert addAction:okAction];
@@ -415,7 +421,7 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     SWITCH_ITEM2(LOC(@"Disable Modern Buttons"), LOC(@"This will remove the new Modern / Chip Buttons in the YouTube App. but not all of them. App restart is required."), @"disableModernButtons_enabled");
     SWITCH_ITEM2(LOC(@"Disable Rounded Corners on Hints"), LOC(@"This will make the Hints in the App to not have Rounded Corners. App restart is required."), @"disableRoundedHints_enabled");
     SWITCH_ITEM2(LOC(@"Disable Modern A/B Flags"), LOC(@"This will turn off any Modern Flag that was enabled by default. App restart is required."), @"disableModernFlags_enabled");
-    SWITCH_ITEM2(LOC(@"Enable Specific UI Related Options (YTNoModernUI)"), LOC(@"When Enabled, this will enable other options to give it a less-modern feeling. App restart is required."), @"ytNoModernUI_enabled");
+    SWITCH_ITEM2(LOC(@"Enable Specific UI Related Options (YTNoModernUI)"), LOC(@"This will force-enable other options to give it a less-modern feeling. App restart is required."), @"ytNoModernUI_enabled");
     SWITCH_ITEM2(LOC(@"Enable App Version Spoofer"), LOC(@"Enable this to use the Version Spoofer and select your perferred version below. App restart is required."), @"enableVersionSpoofer_enabled");
     YTSettingsSectionItem *versionSpoofer = [%c(YTSettingsSectionItem)
         itemWithTitle:@"Version spoofer picker"
@@ -1020,8 +1026,6 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
     accessibilityIdentifier:nil
     switchOn:IS_ENABLED(@"youTabFakePremium_enabled")
     switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
-        // Store the received value
-        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"youTabFakePremium_enabled"];
         // Get the current version (including spoofed versions)
         Class YTVersionUtilsClass = %c(YTVersionUtils);
         NSString *appVersion = [YTVersionUtilsClass performSelector:@selector(appVersion)];
@@ -1034,6 +1038,7 @@ YTSettingsSectionItem *lowContrastModeButton = [%c(YTSettingsSectionItem)
             [settingsViewController presentViewController:alert animated:YES completion:nil];
         }
         // Refresh data and show the relaunch popup
+        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"youTabFakePremium_enabled"];
         [settingsViewController reloadData];
         SHOW_RELAUNCH_YT_SNACKBAR;
         return YES;


### PR DESCRIPTION
Many changes here: 

- Fake Premium: Avoid modifying model when the version is spoofed below version
- New SwitchItem3: This switch makes it easier (hopefully) to create switches with custom code.
- Low Contrast Mode: This setting now checks the spoofed version instead of the real version
- Fake Premium: This setting now checks the spoofed version instead of the real version
- YTNoModernUI: Add a popup that warns that other settings will be kept on

Closes #593
Closes #587 