### PR TITLE
Cleanup Build Workflow

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -7,43 +7,43 @@ on:
   workflow_dispatch:
     inputs:
       sdk_version:
-        description: "iOS SDK version to be used during build"
+        description: "iOS SDK Version"
         default: "16.4"
         required: true
         type: string
       uyou_version:
-        description: "The version of uYou"
+        description: "uYou Version"
         default: "3.0.3"
         required: true
         type: string
-      uyouenhanced_version:
-        description: "The version of uYouEnhanced (Commit ID)"
-        default: ""
-        required: false
-        type: string
       decrypted_youtube_url:
-        description: "The direct URL to the decrypted YouTube ipa"
+        description: "Direct URL of the decrypted YouTube IPA"
         default: ""
         required: true
         type: string
       bundle_id:
-        description: "Modify the bundle ID. Not recommended"
+        description: "Modify the bundle ID"
         default: "com.google.ios.youtube"
         required: true
         type: string
       app_name:
-        description: "Modify the name of the app on the Home Screen. Not recommended"
+        description: "Modify the app name"
         default: "YouTube"
         required: true
         type: string
-      create_release:
-        description: "Create a draft release"
+      commit_id:
+        description: "(Optional) Commit ID to build at"
+        default: ""
+        required: false
+        type: string
+      upload_artifact:
+        description: "Upload IPA as artifact"
         default: true
         required: false
         type: boolean
-      upload_artifact:
-        description: "Upload Artifact"
-        default: true
+      create_release:
+        description: "Create a draft release"
+        default: false
         required: false
         type: boolean
   
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           path: main
-          ref: ${{ github.event.inputs.uyouenhanced_version || github.ref }}
+          ref: ${{ github.event.inputs.commit_id || github.ref }}
           submodules: recursive
 
       - name: Install Dependencies
@@ -161,15 +161,15 @@ jobs:
           if-no-files-found: error
 
       - name: Create Release
+        if: inputs.create_release == 'true'
         id: create_release
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UYOU_VERSION: ${{ inputs.uyou_version }}
           YOUTUBE_VERSION: ${{ steps.prepare_youtube.outputs.youtube_version }}
-          DRAFT: ${{ inputs.create_release }}
         with:
           tag_name: v${{ env.YOUTUBE_VERSION }}-${{ env.UYOU_VERSION }}-(${{ github.run_number }})
           name: v${{ env.YOUTUBE_VERSION }}-${{ env.UYOU_VERSION }}-(${{ github.run_number }})
           files: main/packages/*.ipa
-          draft: ${{ env.DRAFT }}
+          draft: true


### PR DESCRIPTION
I tried to make the build menu more intuitive to use

![image](https://github.com/arichornlover/uYouEnhanced/assets/34104885/94e8e7de-043a-4227-a2ef-1106cd38e49d)

Changes made
- Cleaned up text fragments
- Moved Commit ID to bottom
- Moved Upload Artifact up
- It is no longer possible to make a full release from the build menu. Now, enabling `Create a Draft Release` will create a draft release. Leaving it disabled will make it do nothing.

Closes #602 

Let me know what you think of these changes, I am open to making modifications